### PR TITLE
Console: skip the progress spinner when stdout is redirected

### DIFF
--- a/KismetEditor/Solicen/CLI/Console.cs
+++ b/KismetEditor/Solicen/CLI/Console.cs
@@ -215,6 +215,15 @@ namespace Solicen.CLI
         /// <param name="message">Сообщение, отображаемое рядом с индикатором.</param>
         public static void StartProgress(string message)
         {
+            // Spinner manipulates the cursor (CursorLeft / SetCursorPosition); without an
+            // interactive TTY those throw IOException, which escapes the async Task as an
+            // unobserved exception. Fall back to a plain WriteLine.
+            if (System.Console.IsOutputRedirected)
+            {
+                WriteLine(message);
+                return;
+            }
+
             // Останавливаем предыдущий индикатор, если он был запущен
             StopProgress();
             System.Console.WriteLine();


### PR DESCRIPTION
## Problem

When `KissE.exe` is run with stdout redirected — CI runners, pipes, non-interactive wrappers like `Start-Process -RedirectStandardOutput`, or shells that pipe output to a logger — the spinner `Task` started by `StartProgress` reads `Console.CursorLeft` and calls `Console.SetCursorPosition`, both of which throw `IOException` (\"Handle is invalid\") because there is no real TTY attached.

The exception is raised inside an async `Task` so it becomes an *unobserved* exception. Depending on .NET runtime settings it later surfaces as an unhandled-exception process exit, **after the actual asset modification is already done**. The user sees a non-zero exit code (often `-532462766` = `0xE0434352`) and a stack trace, even though the work succeeded.

## Reproducer

Any KissE invocation with redirected output:

```powershell
KissE.exe my.json my.uasset --map=mappings.usmap --version=5.3 > out.log 2>&1
```

or via PowerShell:

```powershell
Start-Process -FilePath KissE.exe -ArgumentList ... -RedirectStandardOutput out.log -Wait
```

Before this change: the asset is patched, then KissE exits with a non-zero code and a stack trace mentioning `Console.get_CursorLeft()` and `Console.SetCursorPosition`.

After this change: the asset is patched, the spinner is replaced by a single line printed to stdout, and KissE exits cleanly with code 0.

## Change

At the very start of `StartProgress`, fall back to a `WriteLine(message)` when `Console.IsOutputRedirected` is `true`. The interactive-TTY path is otherwise untouched.

\`\`\`csharp
public static void StartProgress(string message)
{
    if (System.Console.IsOutputRedirected)
    {
        WriteLine(message);
        return;
    }
    // ... existing code unchanged
}
\`\`\`

\`Console.IsOutputRedirected\` is the canonical .NET API for this check (it returns \`true\` when stdout is not a console, which is exactly the condition under which \`CursorLeft\`/\`SetCursorPosition\` will fail).

## Tests

Manual:
- Interactive run in \`cmd.exe\` / PowerShell terminal — spinner still animates as before.
- Redirected run (\`> out.log\`) — message printed once, no exception, exit 0.

## Notes

Developed with assistance from [Claude Code](https://claude.com/claude-code).