### PR TITLE
KismetExtension: match the ubergraph by ObjectName instead of by bytecode size

### DIFF
--- a/KismetEditor/Solicen/Kismet/KismetExtension.cs
+++ b/KismetEditor/Solicen/Kismet/KismetExtension.cs
@@ -53,11 +53,21 @@ namespace Solicen.Kismet
             JArray exports = (JArray)jsonObject["Exports"];
             if (exports == null) return null;
 
-            // Примечание: Очень нестабильное получение Ubergraph если любая другая
-            //             инструкция выйдет за пределы 100 байтов.
+            // Prefer ObjectName "ExecuteUbergraph*" (stable, matches the UAsset overload
+            // below); fall back to the size heuristic when ObjectName isn't in the JSON.
+            var byName = exports
+                .OfType<JObject>()
+                .FirstOrDefault(e => e.ContainsKey("ScriptBytecode")
+                    && e["ObjectName"]?.ToString() is string name
+                    && name.StartsWith("ExecuteUbergraph", StringComparison.Ordinal));
+            if (byName != null)
+            {
+                return byName["ScriptBytecode"] as JArray;
+            }
+
             var ubergraphExport = exports
                 .OfType<JObject>()
-                .FirstOrDefault(e => e.ContainsKey("ScriptBytecode") 
+                .FirstOrDefault(e => e.ContainsKey("ScriptBytecode")
                 && int.Parse(e["ScriptBytecodeSize"].ToString()) > 100);
             return ubergraphExport?["ScriptBytecode"] as JArray;
         }


### PR DESCRIPTION
## Problem

The JSON-side `GetUbergraph(JObject)` picks the ubergraph by *"first export whose `ScriptBytecodeSize` is greater than 100 bytes"*. The existing comment already flags this as fragile:

```csharp
// Примечание: Очень нестабильное получение Ubergraph если любая другая
//             инструкция выйдет за пределы 100 байтов.
```

On assets where any other function (a widget event handler with non-trivial logic, a function library export, an `OnConstruction` body, etc.) also ships a bytecode larger than the 100-byte threshold, the wrong export is returned. The replacement walkers downstream then silently see zero matches: KissE reports 0 modifications without any error, even though the input JSON is fine.

The `GetUbergraph(UAsset)` overload right below already does the right thing: it picks by `ObjectName.StartsWith("ExecuteUbergraph")`, which is the stable Blueprint convention.

## Change

Align the JSON overload with the asset overload: try `ObjectName` first, fall back to the size heuristic when `ObjectName` is not exposed in the JSON view (defence-in-depth, previous behaviour preserved).

```csharp
public static JArray GetUbergraph(JObject jsonObject)
{
    JArray exports = (JArray)jsonObject["Exports"];
    if (exports == null) return null;

    var byName = exports
        .OfType<JObject>()
        .FirstOrDefault(e => e.ContainsKey("ScriptBytecode")
            && e["ObjectName"]?.ToString()?.StartsWith("ExecuteUbergraph") == true);
    if (byName != null) return byName["ScriptBytecode"] as JArray;

    // Existing fallback unchanged.
    var ubergraphExport = exports
        .OfType<JObject>()
        .FirstOrDefault(e => e.ContainsKey("ScriptBytecode")
        && int.Parse(e["ScriptBytecodeSize"].ToString()) > 100);
    return ubergraphExport?["ScriptBytecode"] as JArray;
}
```

## Tests

Manual:
- Asset where the ubergraph is the largest export — both lookups return the same `JArray`, behaviour unchanged.
- Asset where a non-ubergraph export crosses the 100-byte threshold — the new lookup returns the correct ubergraph; replacement walkers see the expected matches.

## Notes

Developed with assistance from [Claude Code](https://claude.com/claude-code).