### PR TITLE
KismetProcessor: compute MAGIC_TES / MAGIC_FES offsets via KismetExpression.Visit

### DIFF
--- a/KismetEditor/Solicen/Kismet/KismetProcessor.cs
+++ b/KismetEditor/Solicen/Kismet/KismetProcessor.cs
@@ -12,6 +12,7 @@ using System.Text.RegularExpressions;
 using UAssetAPI;
 using UAssetAPI.Kismet;
 using UAssetAPI.Kismet.Bytecode;
+using UAssetAPI.Kismet.Bytecode.Expressions;
 using UAssetAPI.PropertyTypes.Structs;
 using UAssetAPI.Unversioned;
 
@@ -131,25 +132,46 @@ namespace Solicen
             bool replaced = FindAndReplaceRecursively(liveUbergraph, liveUbergraph, bytecode, replaceFrom, replaceTo);
             if (replaced)
             {
-                // Шаги 6-8: Если замена произошла, пересчитываем смещения
-                //Console.WriteLine("[INF] Recalculation and patching of offsets...");
-                // Для пересчета нам снова нужен сериализованный ассет
+                // Re-deserialize so the new ScriptBytecode reflects the placeholder + jump
+                // and the appended modified statement + return jump.
                 Asset = UAsset.DeserializeJson(assetJsonObject.ToString());
-                var newUbergraph = KismetExtension.GetUbergraphJson(Asset);   
 
-                // Для получения карты смещений нам нужен полный список инструкций
-                var newInstructionMap = MapParser.CreateMap(newUbergraph, Asset, false);
-                //var debugMap = MapParser.CreateMap(newUbergraph, asset, true);
-                var newToEnd = OffsetCalculator.GetOffset(newInstructionMap, MAGIC_TES);
-                var newFromEnd = OffsetCalculator.GetOffset(newInstructionMap, MAGIC_FES);
+                // Compute MAGIC_TES / MAGIC_FES targets via KismetExpression.Visit(),
+                // which mirrors ExpressionSerializer.WriteExpression byte-for-byte. The
+                // SerializeScript + StatementIndex pipeline can drift from the actual
+                // Write() output on some bytecode shapes, leaving magic-numbers patched
+                // mid-instruction.
+                var newBytecode = KismetExtension.GetUbergraph(Asset);
+                int idxTes = -1;
+                int idxFes = -1;
+                var topLevelOffsets = new uint[newBytecode.Length];
+                uint runningOffset = 0;
+                for (int i = 0; i < newBytecode.Length; i++)
+                {
+                    topLevelOffsets[i] = runningOffset;
+                    var ex = newBytecode[i];
+                    if (ex is EX_Jump jx)
+                    {
+                        if (jx.CodeOffset == MAGIC_TES && idxTes < 0)
+                        {
+                            idxTes = i;
+                        }
+                        else if (jx.CodeOffset == MAGIC_FES && idxFes < 0)
+                        {
+                            idxFes = i;
+                        }
+                    }
+                    uint after = runningOffset;
+                    ex.Visit(Asset, ref after, (_, _) => { });
+                    runningOffset = after;
+                }
+
+                int newToEnd = idxTes >= 0 && idxTes + 2 < topLevelOffsets.Length ? (int)topLevelOffsets[idxTes + 2] : 0;
+                int newFromEnd = idxFes >= 1 ? (int)topLevelOffsets[idxFes - 1] : 0;
 
                 if (newToEnd <= 0 || newFromEnd <= 0)
                 {
                     Console.WriteLine($"[WRN] Offsets could not be calculated (ToEnd: {newToEnd}, FromEnd: {newFromEnd}). The process may be unstable.");
-                }
-                else
-                {
-                    //Console.WriteLine($"[INF] New offsets have been calculated (ToEnd -> {newToEnd}, FromEnd -> {newFromEnd})");
                 }
 
                 // Заменяем магические числа на реальные смещения в "живом" JObject


### PR DESCRIPTION
## Problem

After `FindAndReplaceRecursively` inserts a placeholder + `EX_Jump(MAGIC_TES)` at the original site and appends the modified statement + `EX_Jump(MAGIC_FES)` at the end of the bytecode, KissE has to compute the real binary offsets for those two jumps and patch them into the live JSON. The current path is:

```
KismetSerializer.SerializeScript  →  JSON tagged with StatementIndex
                                  →  MapParser.CreateMap
                                  →  OffsetCalculator.GetOffset(MAGIC_*)
```

The `StatementIndex` annotations produced by `SerializeScript` are *intended* to be the binary offsets that `StructExport.Write` will emit, but for some bytecode shapes they **drift** from the real `Write()` output. The case I hit was a UFunction whose top-level statements include an `EX_SwitchValue` plus a couple of `EX_Context` blocks: `StatementIndex` for the appended statements came back 18 bytes too low, so the magic jumps were patched with offsets pointing **mid-instruction** in another `EX_Let`. The runtime then read a junk byte where it expected an opcode and crashed:

```
LowLevelFatalError [...] Encountered an undefined opcode (0xEC) at byte offset 5,750.
```

The corruption is silent on KissE's side — the `[WRN] Offsets could not be calculated` warning never fires because the values *are* non-zero, just wrong.

## Change

Replace the `SerializeScript + StatementIndex + OffsetCalculator` block in `ReplaceSingle` with a direct `KismetExpression.Visit()` walk over the freshly-deserialized `ScriptBytecode`. `Visit` mirrors `ExpressionSerializer.WriteExpression` byte-for-byte (it is the API both `Write` and the asset-side offset bookkeeping use), so the offsets it accumulates are exactly what the asset contains on disk.

```csharp
var newBytecode = KismetExtension.GetUbergraph(Asset);
int idxTes = -1, idxFes = -1;
var topLevelOffsets = new uint[newBytecode.Length];
uint runningOffset = 0;
for (int i = 0; i < newBytecode.Length; i++)
{
    topLevelOffsets[i] = runningOffset;
    var ex = newBytecode[i];
    if (ex is EX_Jump jx)
    {
        if (jx.CodeOffset == MAGIC_TES && idxTes < 0) idxTes = i;
        else if (jx.CodeOffset == MAGIC_FES && idxFes < 0) idxFes = i;
    }
    uint after = runningOffset;
    ex.Visit(Asset, ref after, (_, __) => { });
    runningOffset = after;
}
```

The cross-assignment when patching the magic numbers is preserved (`MAGIC_TES ← FromEnd`, `MAGIC_FES ← ToEnd`), and the `[WRN]` warning still fires on degenerate inputs. The diff is local to `ReplaceSingle`.

`MapParser` and `OffsetCalculator` are kept in the codebase — they are still useful for the extract path / diagnostics — but are no longer on the hot path of replacement.

## Tests

Manual:
- A function whose only top-level statements are simple `EX_Let` chains: same offsets as before, no behaviour change, output binaries are byte-identical to the previous KissE.
- A function that mixes `EX_SwitchValue` and `EX_Context` (the originally failing case): magic jumps now land on `EX_Let` starts (verified by walking the resulting `ScriptBytecode` again with `Visit()` and checking that every jump target appears in the offset table). The asset loads in-game without the `0xEC` crash.

## Notes

The drift between `SerializeScript.StatementIndex` and `Write()` output is arguably an UAssetAPI bug rather than a KissE one. This PR sidesteps it from the consumer side by relying on `Visit()` (which is the canonical API for "what offsets will end up in the file"). A separate UAssetAPI issue/PR could fix `SerializeScript` at the source if anyone wants to investigate.

Developed with assistance from [Claude Code](https://claude.com/claude-code).