### PR TITLE
KismetProcessor: add --patch-assignments to opt into AssignmentExpression replacements

### DIFF
--- a/KismetEditor/Solicen/CLI/CLIHandler.cs
+++ b/KismetEditor/Solicen/CLI/CLIHandler.cs
@@ -32,6 +32,7 @@ namespace Solicen.CLI
             public static bool NoBak = false;
             public static bool AllowLocalizedSource = false;
             public static bool AllowUnderscore = false;
+            public static bool PatchAssignments { get; set; } = false;
         }
         private static readonly string[] NotAllowedPath = new[] { 
             "\\ThirdParty\\", "\\Materials\\", "\\Terrain\\", "\\Effects\\", "\\FX\\",
@@ -55,6 +56,7 @@ namespace Solicen.CLI
                 new Argument("--table", null, "Extract strings from Data/String Table assets.", () => Config.AllowTable = true),
                 new Argument("--localized", "-l", "Extract fallback localization strings (LocalizedSource). [RISKY]", () => Config.AllowLocalizedSource = true),
                 new Argument("--underscore", "-u", "Allow extracting strings that contain the '_' character.", () => Config.AllowUnderscore = true),
+                new Argument("--patch-assignments", null, "Also replace EX_StringConst inside an AssignmentExpression in the ubergraph (off by default; opt-in for game text hardcoded via 'Set Text' / 'Print String' Blueprint nodes).", () => Config.PatchAssignments = true),
                 new Argument("--debug", "-d", "Enables debug mode with additional information output.",() => Config.DebugMode = true),
                 new Argument("--help", "-h", "Show this help message.", () => Argumentor.ShowHelp(arguments)),
                 new Argument("--uexp", "-exp", "Include uexp files to process.", () => Config.IncludeUexpFiles = true),

--- a/KismetEditor/Solicen/Kismet/KismetProcessor.cs
+++ b/KismetEditor/Solicen/Kismet/KismetProcessor.cs
@@ -220,10 +220,11 @@ namespace Solicen
                     {
                         //Console.WriteLine($"[INF] A candidate with the string '{replaceFrom.Escape()}' was found. Apply filters...");
                         // Применяем фильтры
-                        if (token.Ancestors().Any(ancestor => ancestor is JProperty prop && prop.Name == "AssignmentExpression"))
+                        if (!CLI.CLIHandler.Config.PatchAssignments
+                            && token.Ancestors().Any(ancestor => ancestor is JProperty prop && prop.Name == "AssignmentExpression"))
                         {
                             //Console.WriteLine("[INF] Filtered: located in the 'AssignmentExpression'.");
-                            return false; // Продолжаем поиск
+                            return false; // skipped unless --patch-assignments
                         }
 
                         // Шаг 1-3: Находим корневой Statement в "живом" уберграфе

--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ Made with ❤️ for **all** translators and translation developers.
   | `--table` | Extract strings from Data/String Table assets.
   | `--localized` `-l` | Extract fallback localization strings (LocalizedSource) [RISKY]
   | `--underscore` `-u` | Allow extracting strings that contain the '_' character.
+  | `--patch-assignments` | Also replace (EX_StringConst) inside an AssignmentExpression in the ubergraph (off by default to avoid touching technical paths/keys; opt-in for game text hardcoded via 'Set Text' / 'Print String' Blueprint nodes).
   | `--table:only:key` | If key/name matches then include only this value to output (e.g., --table:only:key=ENG)
   | `--pack:folder` `-p:f` | Translate and pack assets into auto prepared folder (e.g., "ManicMiners_RUS")
   | `--version` `-v` | Set the engine version for correct processing (e.g., -v=5.1)


### PR DESCRIPTION
By default `FindAndReplaceRecursively` skips any `EX_StringConst` whose ancestor chain includes an `AssignmentExpression`. That filter exists for good reasons - it avoids touching technical paths and keys - but it also hides every Blueprint string that lives behind an `EX_Let`, which is the typical shape of "Set Text" widget bindings and "Print String" tutorial literals.

This PR adds a CLI flag `--patch-assignments` (off by default to preserve current behaviour). When set, the `AssignmentExpression` filter is skipped, so those `EX_StringConst` nodes become eligible for replacement. The existing placeholder + `MAGIC_TES`/`MAGIC_FES` offset-recalculation pipeline handles the resulting bytecode-length change without further changes.

Two-line code change:
- `CLIHandler`: `Config.PatchAssignments` + new `Argument` entry.
- `KismetProcessor.FindAndReplaceRecursively`: gate the existing filter behind the new flag.

Validated on Unreal Engine 5.3 assets (A Bumpy Ride) where Print String tutorial literals and widget "Set Text" bindings became patchable end-to-end without further changes.

Independent of #4/#5/#6 (already merged) and of the companion PR for `--patch-all-functions`.

Developed with assistance from Claude Code.