### PR TITLE
Add --patch-all-functions to extend the replace pipeline beyond the ubergraph

### DIFF
--- a/KismetEditor/Solicen/CLI/CLIHandler.cs
+++ b/KismetEditor/Solicen/CLI/CLIHandler.cs
@@ -32,6 +32,7 @@ namespace Solicen.CLI
             public static bool NoBak = false;
             public static bool AllowLocalizedSource = false;
             public static bool AllowUnderscore = false;
+            public static bool PatchAllFunctions { get; set; } = false;
         }
         private static readonly string[] NotAllowedPath = new[] { 
             "\\ThirdParty\\", "\\Materials\\", "\\Terrain\\", "\\Effects\\", "\\FX\\",
@@ -55,6 +56,7 @@ namespace Solicen.CLI
                 new Argument("--table", null, "Extract strings from Data/String Table assets.", () => Config.AllowTable = true),
                 new Argument("--localized", "-l", "Extract fallback localization strings (LocalizedSource). [RISKY]", () => Config.AllowLocalizedSource = true),
                 new Argument("--underscore", "-u", "Allow extracting strings that contain the '_' character.", () => Config.AllowUnderscore = true),
+                new Argument("--patch-all-functions", null, "Iterate the bytecode-replacement pipeline over every UFunction with a ScriptBytecode (not just ExecuteUbergraph_*). Needed for widget event handlers and other functions that hold their EX_StringConst outside the ubergraph.", () => Config.PatchAllFunctions = true),
                 new Argument("--debug", "-d", "Enables debug mode with additional information output.",() => Config.DebugMode = true),
                 new Argument("--help", "-h", "Show this help message.", () => Argumentor.ShowHelp(arguments)),
                 new Argument("--uexp", "-exp", "Include uexp files to process.", () => Config.IncludeUexpFiles = true),

--- a/KismetEditor/Solicen/Kismet/InstructionSearchSize.cs
+++ b/KismetEditor/Solicen/Kismet/InstructionSearchSize.cs
@@ -49,6 +49,10 @@ namespace Solicen.Kismet
             if (expAsset == null) return 0; // Если ничего не найдено, отправляем 0 как ошибку.
             #endregion
 
+            // SerializeExpression resolves names through KismetSerializer.asset (a static).
+            // Reset it for the current asset, otherwise GetFullName throws NullReferenceException
+            // when iterating UFunctions other than the one most recently passed through GetUbergraphJson.
+            KismetSerializer.asset = asset;
             KismetSerializer.SerializeExpression(expAsset, ref totalSize, true);
             if (DebugOutput)
             {

--- a/KismetEditor/Solicen/Kismet/KismetBytecodeModifier.cs
+++ b/KismetEditor/Solicen/Kismet/KismetBytecodeModifier.cs
@@ -71,15 +71,19 @@ namespace Solicen.Kismet
 
             }
 
-            var ubergraph = KismetExtension.GetUbergraphJson(Asset);
-            if (ubergraph != null)
+            if (CLI.CLIHandler.Config.PatchAllFunctions)
             {
-
-
                 replacement = RemoveAnyCode(replacement);
-                KismetProcessor.ReplaceAllInUbergraph(replacement, ref Asset);
-
-
+                KismetProcessor.ReplaceAllInAllFunctions(replacement, ref Asset);
+            }
+            else
+            {
+                var ubergraph = KismetExtension.GetUbergraphJson(Asset);
+                if (ubergraph != null)
+                {
+                    replacement = RemoveAnyCode(replacement);
+                    KismetProcessor.ReplaceAllInUbergraph(replacement, ref Asset);
+                }
             }
 
             // --- Отладочный вывод и безопасный режим (без сохранения) ---

--- a/KismetEditor/Solicen/Kismet/KismetExtension.cs
+++ b/KismetEditor/Solicen/Kismet/KismetExtension.cs
@@ -92,6 +92,59 @@ namespace Solicen.Kismet
 
         }
 
+        /// <summary>
+        /// Returns every export with a non-empty ScriptBytecode, paired with the corresponding
+        /// JArray inside <paramref name="jsonObject"/> (the live, mutable copy used for
+        /// replacement) and the deserialized <c>KismetExpression[]</c> from
+        /// <paramref name="asset"/> (used for size/offset calculations).
+        /// Used by --patch-all-functions to extend the replace pipeline beyond the single
+        /// ExecuteUbergraph_* function.
+        /// </summary>
+        public static List<(string name, JArray jsonBytecode, KismetExpression[] exprBytecode)>
+            GetAllScriptBytecode(JObject jsonObject, UAsset asset)
+        {
+            var result = new List<(string, JArray, KismetExpression[])>();
+            if (asset == null || jsonObject == null)
+            {
+                return result;
+            }
 
+            var assetByName = new Dictionary<string, KismetExpression[]>();
+            foreach (var ex in asset.Exports)
+            {
+                if (ex is StructExport se && se.ScriptBytecode != null && se.ScriptBytecode.Length > 0)
+                {
+                    assetByName[ex.ObjectName.ToString()] = se.ScriptBytecode;
+                }
+            }
+
+            if (jsonObject["Exports"] is not JArray jExports)
+            {
+                return result;
+            }
+
+            foreach (var jExp in jExports.OfType<JObject>())
+            {
+                if (!jExp.ContainsKey("ScriptBytecode"))
+                {
+                    continue;
+                }
+                var name = jExp["ObjectName"]?.ToString();
+                if (name == null)
+                {
+                    continue;
+                }
+                if (!assetByName.TryGetValue(name, out var expr))
+                {
+                    continue;
+                }
+                if (jExp["ScriptBytecode"] is not JArray jBc || jBc.Count == 0)
+                {
+                    continue;
+                }
+                result.Add((name, jBc, expr));
+            }
+            return result;
+        }
     }
 }

--- a/KismetEditor/Solicen/Kismet/KismetProcessor.cs
+++ b/KismetEditor/Solicen/Kismet/KismetProcessor.cs
@@ -10,6 +10,7 @@ using System.Runtime.InteropServices.JavaScript;
 using System.Text.Json.Nodes;
 using System.Text.RegularExpressions;
 using UAssetAPI;
+using UAssetAPI.ExportTypes;
 using UAssetAPI.Kismet;
 using UAssetAPI.Kismet.Bytecode;
 using UAssetAPI.Kismet.Bytecode.Expressions;
@@ -84,6 +85,112 @@ namespace Solicen
                     ModifiedCount += replaced;
                 }
             }
+        }
+
+        /// <summary>
+        /// Like <see cref="ReplaceAllInUbergraph"/> but iterates the replacement pipeline over
+        /// every UFunction with a ScriptBytecode (not just ExecuteUbergraph_*). Required for
+        /// EX_StringConst literals living in widget event handlers and similar functions that
+        /// the ubergraph-only pipeline ignores.
+        /// </summary>
+        public static void ReplaceAllInAllFunctions(Dictionary<string, string> replacement, ref UAsset _Asset)
+        {
+            Asset = _Asset;
+            var assetJsonObject = JObject.Parse(Asset.SerializeJson());
+            var tempUsmap = Asset.Mappings != null ? Asset.Mappings : new Usmap();
+
+            foreach (var entry in replacement)
+            {
+                string from = entry.Key;
+                string to = entry.Value;
+                bool anyThisRound = true;
+                while (anyThisRound)
+                {
+                    anyThisRound = false;
+                    // Re-fetch each iteration: Asset is re-deserialized after each successful
+                    // replace, invalidating the cached KismetExpression[] arrays.
+                    var allFns = KismetExtension.GetAllScriptBytecode(assetJsonObject, Asset);
+                    foreach (var fn in allFns)
+                    {
+                        if (ReplaceSingleInFunction(assetJsonObject, fn.name, fn.jsonBytecode, fn.exprBytecode, from, to))
+                        {
+                            anyThisRound = true;
+                            break; // Restart to re-fetch — Asset has been re-deserialized.
+                        }
+                    }
+                }
+            }
+
+            _Asset = UAsset.DeserializeJson(assetJsonObject.ToString());
+            if (tempUsmap.FilePath != null)
+            {
+                _Asset.Mappings = tempUsmap;
+            }
+        }
+
+        private static bool ReplaceSingleInFunction(JObject assetJsonObject, string functionName, JArray liveBytecode, KismetExpression[] exprBytecode, string replaceFrom, string replaceTo)
+        {
+            if (liveBytecode == null)
+            {
+                return false;
+            }
+
+            bool replaced = FindAndReplaceRecursively(liveBytecode, liveBytecode, exprBytecode, replaceFrom, replaceTo);
+            if (!replaced)
+            {
+                return false;
+            }
+
+            // Re-deserialize the asset so the new bytecode array reflects the placeholder + jump
+            // and the appended modified statement + return jump.
+            Asset = UAsset.DeserializeJson(assetJsonObject.ToString());
+
+            var newFn = Asset.Exports.OfType<StructExport>()
+                .FirstOrDefault(e => e.ObjectName.ToString() == functionName);
+            if (newFn == null || newFn.ScriptBytecode == null)
+            {
+                Console.WriteLine($"[WRN] Function '{functionName}' not found in asset after re-deserialize; skipping offset recalculation.");
+                return true;
+            }
+
+            // Compute MAGIC_TES / MAGIC_FES targets via KismetExpression.Visit(), which mirrors
+            // ExpressionSerializer.WriteExpression byte-for-byte and reports the offsets that
+            // StructExport.Write actually emits.
+            int idxTes = -1;
+            int idxFes = -1;
+            uint[] topLevelOffsets = new uint[newFn.ScriptBytecode.Length];
+            uint runningOffset = 0;
+            for (int i = 0; i < newFn.ScriptBytecode.Length; i++)
+            {
+                topLevelOffsets[i] = runningOffset;
+                var ex = newFn.ScriptBytecode[i];
+                if (ex is EX_Jump jx)
+                {
+                    if (jx.CodeOffset == MAGIC_TES && idxTes < 0)
+                    {
+                        idxTes = i;
+                    }
+                    else if (jx.CodeOffset == MAGIC_FES && idxFes < 0)
+                    {
+                        idxFes = i;
+                    }
+                }
+                uint after = runningOffset;
+                ex.Visit(Asset, ref after, (_, _) => { });
+                runningOffset = after;
+            }
+
+            int newToEnd = idxTes >= 0 && idxTes + 2 < topLevelOffsets.Length ? (int)topLevelOffsets[idxTes + 2] : 0;
+            int newFromEnd = idxFes >= 1 ? (int)topLevelOffsets[idxFes - 1] : 0;
+
+            if (newToEnd <= 0 || newFromEnd <= 0)
+            {
+                Console.WriteLine($"[WRN] Offsets could not be calculated for '{functionName}' (ToEnd: {newToEnd}, FromEnd: {newFromEnd}). The process may be unstable.");
+            }
+
+            ReplaceMagicNumber(liveBytecode, MAGIC_TES, newFromEnd);
+            ReplaceMagicNumber(liveBytecode, MAGIC_FES, newToEnd);
+            return true;
         }
 
         public static void ReplaceAllInUbergraph(Dictionary<string, string> replacement, ref UAsset _Asset)

--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ Made with ❤️ for **all** translators and translation developers.
   | `--table` | Extract strings from Data/String Table assets.
   | `--localized` `-l` | Extract fallback localization strings (LocalizedSource) [RISKY]
   | `--underscore` `-u` | Allow extracting strings that contain the '_' character.
+  | `--patch-all-functions` | Iterate the bytecode-replacement pipeline over every UFunction with a ScriptBytecode (not just ExecuteUbergraph_*). Needed for widget event handlers and other functions that hold their (EX_StringConst) outside the ubergraph.
   | `--table:only:key` | If key/name matches then include only this value to output (e.g., --table:only:key=ENG)
   | `--pack:folder` `-p:f` | Translate and pack assets into auto prepared folder (e.g., "ManicMiners_RUS")
   | `--version` `-v` | Set the engine version for correct processing (e.g., -v=5.1)


### PR DESCRIPTION
The default pipeline (`ReplaceAllInUbergraph`) only walks the single `ExecuteUbergraph_*` function. Some game text lives in `EX_StringConst` literals inside other UFunctions - typically widget event handlers wired to `OnClicked` / `OnConstruct` delegates - and those strings are silently skipped today, even with `--patch-assignments`.

This change adds an opt-in CLI flag `--patch-all-functions` (off by default) that iterates the same replace + offset-recalc pipeline over every UFunction with a non-empty `ScriptBytecode`.

Pieces:
- `CLIHandler`: `Config.PatchAllFunctions` + new `Argument` entry.
- `KismetExtension.GetAllScriptBytecode(JObject, UAsset)`: new helper that returns every `(name, jsonBytecode, exprBytecode)` tuple by joining the JSON view and the asset view on `ObjectName`.
- `KismetBytecodeModifier`: route through `ReplaceAllInAllFunctions` when the flag is set.
- `KismetProcessor.ReplaceAllInAllFunctions / ReplaceSingleInFunction`: mirror `ReplaceAllInUbergraph / ReplaceSingle` but accept a target function. The "any-this-round" loop re-fetches functions after each successful replace because `Asset` is re-deserialized in the offset-recalc step, which invalidates the cached `KismetExpression[]` arrays. Offsets are computed via `KismetExpression.Visit()` (same approach as #6), which mirrors `ExpressionSerializer.WriteExpression` byte-for-byte and reports what `StructExport.Write` actually emits.
- `InstructionSearchSize.GetSize`: set `KismetSerializer.asset` before `SerializeExpression`. Without this, `GetFullName` throws a `NullReferenceException` when iterating UFunctions other than the one most recently passed through `GetUbergraphJson` - the static asset reference was set elsewhere and never reset between calls.

Validated on Unreal Engine 5.3 assets (A Bumpy Ride) where widget event-handler labels (shop tab buttons, etc.) became patchable.

Independent of #4/#5/#6 (already merged) and of the companion PR for `--patch-assignments`. If both PRs land, expect a trivial conflict in `CLIHandler.cs` (two consecutive `Argument` entries) - easy to resolve by keeping both.

Developed with assistance from Claude Code.