### PR TITLE
KismetProcessor: shift internal offsets of displaced statement after placement

### DIFF
--- a/KismetEditor/Solicen/Kismet/KismetProcessor.cs
+++ b/KismetEditor/Solicen/Kismet/KismetProcessor.cs
@@ -135,7 +135,8 @@ namespace Solicen
                 return false;
             }
 
-            bool replaced = FindAndReplaceRecursively(liveBytecode, liveBytecode, exprBytecode, replaceFrom, replaceTo);
+            var displacement = new DisplacementInfo();
+            bool replaced = FindAndReplaceRecursively(liveBytecode, liveBytecode, exprBytecode, replaceFrom, replaceTo, displacement);
             if (!replaced)
             {
                 return false;
@@ -190,6 +191,9 @@ namespace Solicen
 
             ReplaceMagicNumber(liveBytecode, MAGIC_TES, newFromEnd);
             ReplaceMagicNumber(liveBytecode, MAGIC_FES, newToEnd);
+
+            ShiftDisplacedStatementInternalOffsets(liveBytecode, newFn.ScriptBytecode, topLevelOffsets, idxTes, displacement);
+
             return true;
         }
 
@@ -236,7 +240,8 @@ namespace Solicen
             }
 
             // Шаг 2: Рекурсивно ищем и сразу заменяем первое найденное вхождение
-            bool replaced = FindAndReplaceRecursively(liveUbergraph, liveUbergraph, bytecode, replaceFrom, replaceTo);
+            var displacement = new DisplacementInfo();
+            bool replaced = FindAndReplaceRecursively(liveUbergraph, liveUbergraph, bytecode, replaceFrom, replaceTo, displacement);
             if (replaced)
             {
                 // Re-deserialize so the new ScriptBytecode reflects the placeholder + jump
@@ -285,6 +290,8 @@ namespace Solicen
                 ReplaceMagicNumber(liveUbergraph, MAGIC_TES, newFromEnd);
                 ReplaceMagicNumber(liveUbergraph, MAGIC_FES, newToEnd);
 
+                ShiftDisplacedStatementInternalOffsets(liveUbergraph, newBytecode, topLevelOffsets, idxTes, displacement);
+
                 return true; // Замена была успешной
             }
 
@@ -312,7 +319,7 @@ namespace Solicen
         }
 
 
-        private static bool FindAndReplaceRecursively(JToken token, JArray scriptBytecodeArray, KismetExpression[] ubergraph, string replaceFrom, string replaceTo)
+        private static bool FindAndReplaceRecursively(JToken token, JArray scriptBytecodeArray, KismetExpression[] ubergraph, string replaceFrom, string replaceTo, DisplacementInfo displacement)
         {
             if (token is JObject obj)
             {
@@ -352,7 +359,36 @@ namespace Solicen
                         int originalIndex = scriptBytecodeArray.IndexOf(statement);
                         if (originalIndex == -1) return false; // Не смогли найти индекс, что-то пошло не так
 
-                        scriptBytecodeArray.RemoveAt(originalIndex);       
+                        // Capture position + size of the string we are about to replace, relative to the
+                        // start of the typed statement. Used later by ShiftDisplacedStatementInternalOffsets
+                        // to apply both the global displacement shift AND the in-statement size shift.
+                        // Walks the TYPED statement pre-modification.
+                        if (originalIndex >= 0 && originalIndex < ubergraph.Length)
+                        {
+                            uint w = 0;
+                            var localDisplacement = displacement;
+                            ubergraph[originalIndex].Visit(Asset, ref w, (e, off) =>
+                            {
+                                if (localDisplacement.RelPos != uint.MaxValue)
+                                {
+                                    return;
+                                }
+                                if (e is EX_StringConst sc && sc.Value == replaceFrom)
+                                {
+                                    localDisplacement.RelPos = off;
+                                    localDisplacement.OldSize = 1 + (sc.Value?.Length ?? 0) + 1;
+                                }
+                                else if (e is EX_UnicodeStringConst usc && usc.Value == replaceFrom)
+                                {
+                                    localDisplacement.RelPos = off;
+                                    localDisplacement.OldSize = 1 + 2 * ((usc.Value?.Length ?? 0) + 1);
+                                }
+                            });
+                            // Modification below always swaps to EX_UnicodeStringConst.
+                            displacement.NewSize = 1 + 2 * ((replaceTo?.Length ?? 0) + 1);
+                        }
+
+                        scriptBytecodeArray.RemoveAt(originalIndex);
                         var size = InstructionSearchSize.GetSize(Asset, statement, ubergraph);
                         /*
                         Console.WriteLine($"[INF] Step 1: Calculate the size of all instructions.");
@@ -393,17 +429,153 @@ namespace Solicen
 
                 foreach (var property in obj.Properties())
                 {
-                    if (FindAndReplaceRecursively(property.Value, scriptBytecodeArray, ubergraph, replaceFrom, replaceTo)) return true;
+                    if (FindAndReplaceRecursively(property.Value, scriptBytecodeArray, ubergraph, replaceFrom, replaceTo, displacement))
+                    {
+                        return true;
+                    }
                 }
             }
             else if (token is JArray array)
             {
                 foreach (var item in array)
                 {
-                    if (FindAndReplaceRecursively(item, scriptBytecodeArray, ubergraph, replaceFrom, replaceTo)) return true;
+                    if (FindAndReplaceRecursively(item, scriptBytecodeArray, ubergraph, replaceFrom, replaceTo, displacement))
+                    {
+                        return true;
+                    }
                 }
             }
             return false;
+        }
+
+        /// <summary>
+        /// Names of opcode fields that hold absolute byte positions inside the same bytecode buffer
+        /// (and therefore become stale when a statement is physically displaced).
+        /// </summary>
+        private static readonly string[] AbsoluteOffsetFieldNames =
+        {
+            "CodeOffset",     // EX_Jump, EX_JumpIfNot, EX_Skip
+            "EndGotoOffset",  // EX_SwitchValue
+            "NextOffset",     // FKismetSwitchCase (inside EX_SwitchValue.Cases)
+            "PushingAddress", // EX_PushExecutionFlow
+        };
+
+        /// <summary>
+        /// Carries the string-position and size info captured during FindAndReplaceRecursively
+        /// to ShiftDisplacedStatementInternalOffsets. Allows the shifter to distinguish
+        /// "before the replaced string" (shift by relocDelta only) from "after the replaced
+        /// string" (shift by relocDelta + internalDelta) when computing the final shift for
+        /// each internal absolute offset.
+        ///
+        /// Passed explicitly through the call chain rather than via static state, so that
+        /// nested invocations of FindAndReplaceRecursively (recursive walks, nested
+        /// replacement attempts) don't accidentally clobber each other's data.
+        /// </summary>
+        private class DisplacementInfo
+        {
+            public uint RelPos = uint.MaxValue;
+            public int OldSize = 0;
+            public int NewSize = 0;
+        }
+
+        /// <summary>
+        /// After FindAndReplaceRecursively has displaced the modified statement to the end of the
+        /// bytecode (and inserted EX_Jump+placeholder at its original position), the statement's
+        /// internal absolute offsets (e.g. EX_SwitchValue.EndGotoOffset, EX_Jump.CodeOffset inside
+        /// the statement) still point at byte positions from the OLD layout. For offsets whose
+        /// target falls inside the statement's original byte range, those bytes have moved by
+        /// relocDelta = newPos - oldPos. This walks the displaced statement's JSON subtree and
+        /// adds relocDelta to any absolute-offset field whose value is in the original range.
+        ///
+        /// Without this fix, default branches of EX_SwitchValue and similar in-statement jumps
+        /// land mid-instruction in the patched bytecode, causing "undefined opcode" / "infinite
+        /// script recursion" crashes at runtime on the affected branches.
+        /// </summary>
+        private static void ShiftDisplacedStatementInternalOffsets(JArray liveBytecode, KismetExpression[] newBytecode, uint[] topLevelOffsets, int idxTes, DisplacementInfo displacement)
+        {
+            if (idxTes < 0 || idxTes + 2 > topLevelOffsets.Length - 1)
+            {
+                return;
+            }
+            if (liveBytecode == null || liveBytecode.Count < 2)
+            {
+                return;
+            }
+            if (newBytecode == null || newBytecode.Length < 2)
+            {
+                return;
+            }
+
+            int dispJsonIdx = liveBytecode.Count - 2;     // displaced statement is just before the return jump
+            int dispExprIdx = newBytecode.Length - 2;
+
+            if (dispJsonIdx <= idxTes + 1 || dispExprIdx <= idxTes + 1)
+            {
+                return;
+            }
+            if (dispJsonIdx >= liveBytecode.Count)
+            {
+                return;
+            }
+            if (!(liveBytecode[dispJsonIdx] is JObject dispJson))
+            {
+                return;
+            }
+
+            uint oldStmtPos = topLevelOffsets[idxTes];       // position of the placeholder == original position of statement
+            uint oldStmtEnd = topLevelOffsets[idxTes + 2];   // start of the next original statement
+            uint newStmtPos = topLevelOffsets[dispExprIdx];  // position of the displaced statement at the end of bytecode
+            long relocDelta = (long)newStmtPos - (long)oldStmtPos;
+
+            if (relocDelta == 0 && displacement.RelPos == uint.MaxValue)
+            {
+                return;
+            }
+
+            // Compute the absolute byte range of the OLD string (the one we replaced) inside the
+            // OLD bytecode. Internal jump targets that point AFTER this range need an additional
+            // shift of (newStringSize - oldStringSize) because everything after the string was
+            // physically moved within the (now displaced) statement by that delta.
+            int internalDelta = displacement.NewSize - displacement.OldSize;
+            long absOldStringEnd = (displacement.RelPos == uint.MaxValue)
+                ? long.MaxValue
+                : (long)oldStmtPos + displacement.RelPos + displacement.OldSize;
+
+            ShiftInternalOffsetsRecursive(dispJson, oldStmtPos, oldStmtEnd, relocDelta,
+                absOldStringEnd, internalDelta);
+        }
+
+        private static void ShiftInternalOffsetsRecursive(JToken token, uint oldStart, uint oldEnd, long relocDelta,
+            long absStringEnd, int internalDelta)
+        {
+            if (token is JObject obj)
+            {
+                foreach (var fieldName in AbsoluteOffsetFieldNames)
+                {
+                    if (obj.TryGetValue(fieldName, out JToken offsetToken) && offsetToken.Type == JTokenType.Integer)
+                    {
+                        long target = offsetToken.Value<long>();
+                        if (target >= oldStart && target < oldEnd)
+                        {
+                            long extra = (target >= absStringEnd) ? internalDelta : 0L;
+                            obj[fieldName] = target + relocDelta + extra;
+                        }
+                    }
+                }
+                foreach (var prop in obj.Properties())
+                {
+                    ShiftInternalOffsetsRecursive(prop.Value, oldStart, oldEnd, relocDelta,
+                        absStringEnd, internalDelta);
+                }
+            }
+            else if (token is JArray array)
+            {
+                foreach (var item in array)
+                {
+                    ShiftInternalOffsetsRecursive(item, oldStart, oldEnd, relocDelta,
+                        absStringEnd, internalDelta);
+                }
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
## Problem

After `FindAndReplaceRecursively` finishes a successful replacement, the bytecode layout is:

```
[ ... existing statements ... ]
[ EX_Jump(MAGIC_TES) ]         ← at originalIndex, replaces the original statement
[ EX_StringConst placeholder ] ← same total size as the original statement
[ ... existing statements ... ]
[ modified statement ]         ← appended at the end of the bytecode
[ EX_Jump(MAGIC_FES) ]         ← return jump
```

PR #6 (`Visit`-based offset recalc) fixes the two **outer** jumps (MAGIC_TES / MAGIC_FES). What this PR addresses is the offsets stored **inside** the modified statement.

If the displaced statement contains any opcodes with absolute byte offsets that point *within* the statement itself, those offsets still hold their pre-displacement values:

- `EX_Jump.CodeOffset`
- `EX_JumpIfNot.CodeOffset`
- `EX_Skip.CodeOffset`
- `EX_PushExecutionFlow.PushingAddress`
- `EX_SwitchValue.EndGotoOffset`
- `FKismetSwitchCase.NextOffset` (inside `EX_SwitchValue.Cases`)

In the new layout those bytes have moved by `relocDelta = newStmtPos - oldStmtPos`. The stored offsets point to positions inside the *old* range of the statement, which now sit somewhere else (and the bytes at those positions are unrelated instructions). At runtime the VM dispatches the in-statement jump, lands mid-instruction, reads a junk byte as opcode, and crashes:

```
LowLevelFatalError [...] Encountered an undefined opcode (0xE3) at byte offset 41,662.
```

This is non-deterministic because the crash only happens when the VM actually takes the broken branch (e.g. a specific case of a `Switch` node, a default path that's only reached for some game state). The crash log points at the parent function's name (`ExecuteUbergraph_<BPName>:<hexOffset>`), not at KissE.

There is a second source of drift on top of the displacement: replacing the `EX_StringConst` with an `EX_UnicodeStringConst` typically changes the string's serialized size. Internal offsets pointing **after** the string in the statement need an additional shift of `internalDelta = newStringSize - oldStringSize` because the bytes after the string have been physically pushed by that delta.

### Reproduction

Any UFunction whose `replaceFrom` string lives in a top-level statement that also contains an `EX_SwitchValue` (or any of the absolute-offset opcodes listed above) downstream of the string position. In production this happens on Blueprint event graphs where a single `Set Text` / `Print String` node sits in the same node group as a `Switch on String/Int` node or a `Sequence` with explicit flow control.

Concrete repro used during development: `SpecialPassenger.uexp` in A Bumpy Ride (UE5.3.2). The function has 30 `EX_SwitchValue` nested in user-facing-string-bearing statements. KissE swaps `EX_StringConst → EX_UnicodeStringConst` in 4 of those, displaces them to the end of the bytecode, and 4 `EX_SwitchValue.EndGotoOffset` keep their original values (e.g. 18460), which after displacement sit mid-instruction.

## Change

Walks the displaced statement's JSON subtree (the last element of `scriptBytecodeArray` before the return jump) after the magic numbers are patched, and adjusts any `CodeOffset` / `EndGotoOffset` / `NextOffset` / `PushingAddress` field whose value falls inside the statement's original byte range `[oldStmtPos, oldStmtEnd)`.

Two-phase shift:

- target < `absOldStringStart` → `target += relocDelta`
- target ≥ `absOldStringEnd`   → `target += relocDelta + internalDelta`

(target inside the original string's byte range would mean a jump-into-string, which doesn't happen in compiler-emitted bytecode.)

The position and size of the replaced string are captured during `FindAndReplaceRecursively` by walking the typed pre-modification statement once (`KismetExpression.Visit()` reports the position of each sub-expression). These values are carried via a `DisplacementInfo` instance passed through the call chain explicitly (not via static state) so nested recursion or future concurrent invocations don't clobber each other's data.

The new code is invoked from both replacement pipelines:

- `ReplaceSingleInFunction` (used by `--patch-all-functions` mode)
- `ReplaceSingle` (used by the default ubergraph-only mode)

The shifter is unconditional — it runs after every successful replacement. If the displaced statement contains no in-statement absolute offsets (e.g. a simple `EX_LocalVirtualFunction("PrintText", [EX_StringConst])`), the walker visits the JSON tree, finds zero matching fields, and exits without modification. Regression tests below confirm this neutrality.

## Validation

### Static — distance preservation

On the repro case, before this PR the 4 displaced `EX_SwitchValue` keep `EndGotoOffset` values that point to obsolete positions:

| SwitchValue | Vanilla `(nested_off, endGoto, dist)` | Without this PR | With this PR |
|---|---|---|---|
| #1 (cases=7) | (18330, 18460, **130**) | (43732, 18460, drift) | (43732, 43862, **130**) ✓ |
| #2 (cases=6) | (24978, 25111, **133**) | (44675, 25111, drift) | (44675, 44808, **133**) ✓ |
| #3 (cases=6) | (25351, 25484, **133**) | (44966, 25484, drift) | (44966, 45099, **133**) ✓ |
| #4 (cases=13) | (38940, 39160, **220**) | (47481, 39160, drift) | (47481, 47701, **220**) ✓ |

All four `endGoto - nested_off` distances are preserved byte-for-byte vs vanilla, confirming the shift accounts for both relocation and in-statement string expansion.

### Regression — byte-identical on unaffected BPs

Patched 4 BPs from the same project (FR translation JSON), comparing KissE upstream/main vs this branch:

| BP | KissE upstream output | This PR output | Result |
|---|---|---|---|
| SpecialPassenger.uexp | 120540 bytes | 120540 bytes (different md5) | Fix applied |
| Passenger.uexp        | 81453 bytes  | 81453 bytes  (same md5)     | Byte-identical |
| PlayerTrain.uexp      | 231298 bytes | 231298 bytes (same md5)     | Byte-identical |
| Controller.uexp       | 220312 bytes | 220312 bytes (same md5)     | Byte-identical |

All four outputs parse cleanly under UAssetAPI (0 RawExport failures).

### In-game

Repro before this PR: deploying the KissE-patched `SpecialPassenger.uexp` from `--patch-assignments --patch-all-functions` produces a non-deterministic crash at NPC pickup (some task branches, not others). With this PR applied, the same patcher invocation produces an asset that loads and runs through multiple varied task branches without crash.

## Known limitations

- `EX_Context.Offset` is not in the field list above. Empirically (audit on the repro case) this field stores a relative skip size, not an absolute byte position — the values are too small to be absolute offsets into a 40+ KB bytecode. Treating it as absolute would mis-shift it. Leaving it untouched is correct for the repro case; if a future case shows `EX_Context.Offset` actually drifting after displacement, the rule would need to be reconsidered.
